### PR TITLE
Making packing development friendlier

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,13 +4,13 @@
 2. install python3-virtualenv
 3. pip3 install virtualenvwrapper
 4. create a virtualenv for donate with python3
-5. pip install -r requirements.txt -e . (need to check if this is OK for production install)
-6. run `$ pytest`
+5. Install donate in development mode: `$ pip install -r requirements.txt -e .`
+6. run tests `$ pytest`
 7. retrieve or create .env file (or set environment variables as documented below)
-8. flask db init
+8. flask db init 
 9. flask db migrate
 10. flask db upgrade
-11. $ FLASK_ENV=DEVELOPMENT python scripts/initialize_database.py
+11. $ FLASK\_DOTENV=path\_to_.env python scripts/initialize_database.py
 
 # .env example
 
@@ -18,13 +18,15 @@
 FLASK_APP=./autoapp.py
 FLASK_ENV=DEVELOPMENT
 FLASK_DEBUG=1  # do not use this in production.  security vulnerability.
-FLASK_RUN_PORT=5005
+FLASK_RUN_PORT=5000
 
 STRIPE_KEY="<get from stripe admin>"
 STRIPE_SECRET="<get from stripe admin>"
 
 DONATE_SECRET="<random bits of entropy, available in the woodshop>"
 ```
+
+see `dotenv-example` for a working example that uses a sqlite database for development, requiring no extra database config.  Keys need to be generated or aquired from Stripe.
 
 # Database installation
 `$ flask db init` will complain if the migrations directory exists, which it will since it's included in the package.  It's fine.  When it does complain, make sure the directory migrations/versions exists.  If not, just create the directory, but migrations/verions is shipped as well.

--- a/README.rst
+++ b/README.rst
@@ -15,19 +15,4 @@ ____________
 
 See INSTALL.md for instructions on getting the application up and running.
 
-Model Specification
-___________________
 
-Financial data is made up of transactions.  A single transaction exchanges and amount of currency.  Transactions occur between two parties: a payer and a receiver.  While the payer and receiver are people or entities, they are modeled as accounts.  The transaction credits one parties account and debits the other simultaneously.  Two accounts are always involved in each transaction.  The collection of transacations builds the structure for double accounting.
-
-Transactions are requested by people and they are approved by others.  In addition to two accounts, each transaction has at least two people associated with it.
-
-Noisebridge is concerned with two top level objects;  Accounts and Projects.
-
-Accounts have some balance of cash which increases with donations and decreases with spending.  An example is the sewing area: People donate money which is then spent on materials.  
-
-Projects have a stated goal.  A project will have at least one account to track donations.  The progress towards the goal is just the sum of the transactions in this account.
-
-
-.. image:: pics/schema.png
-   :width: 60pt

--- a/dotenv-example
+++ b/dotenv-example
@@ -1,0 +1,34 @@
+# App launcher name
+FLASK_APP=./autoapp.py
+
+# Environment
+FLASK_ENV=DEVELOPMENT
+
+#Debug flag, set to 1 to see helpful tracebacks in browser
+FLASK_DEBUG=1
+
+# App port
+FLASK_RUN_PORT=5000
+
+# Stripe keys
+STRIPE_KEY=""
+STRIPE_SECRET=""
+
+# Donate secret, used for session signing
+DONATE_SECRET=""
+
+# Presently unused
+DONATE_PRODUCT="prod_F4cX7XZmDtbOx"
+
+# Database Credentials
+# DB_USER="dbuser"
+# DB_PASS="dbpass"
+# DB_HOST="localhost"
+# DB_SOCK="/var/run/mysqld/mysqld.sock"
+
+# Example databases
+# DB_PROD_NAME="noisebridge_donate"
+# PROD_DATABASE_URI="mysql+mysqldb://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_PROD_NAME}?unix_socket=${DB_SOCK}"
+
+DB_TEST_NAME="test_donate"
+TEST_DATABASE_URI="sqlite:///${DB_TEST_NAME}"

--- a/scripts/initialize_database.py
+++ b/scripts/initialize_database.py
@@ -1,6 +1,9 @@
+import os
+from dotenv import load_dotenv
+load_dotenv(os.path.join(os.path.dirname(__file__), '../.env'))
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-import os
 from donate.models import (
     DonateConfiguration,
     Currency,
@@ -8,10 +11,6 @@ from donate.models import (
     Project,
 )
 import donate.settings as configs
-from dotenv import load_dotenv
-
-
-load_dotenv(os.path.join(os.path.dirname(__file__), '../.env'))
 
 
 def create_session():


### PR DESCRIPTION
fix up INSTALL.md and a few changes to make creating a dev environment quick.  dotenv-example should work as-is for development except for keys.