### PR TITLE
[WIP] marcidy/quick fix customer

### DIFF
--- a/donate/routes.py
+++ b/donate/routes.py
@@ -155,7 +155,7 @@ def donation():
         flash(msg)
         return redirect('/index#form')
     except se.RateLimitError as error:
-        app.logger.warn("RateLimitError hit!")
+        app.logger.warning("RateLimitError hit!")
         flash("Rate limit hit, please try again in a few seconds")
         return redirect('/index#form')
     except se.StripeError as error:

--- a/donate/routes.py
+++ b/donate/routes.py
@@ -163,6 +163,11 @@ def donation():
         flash("Unexpected error, please check data and try again."
               "  If the error persists, please contact Noisebridge support")
         return redirect('/index#form')
+    except ValueError as error:
+        app.logger.error("ValueError: {}".format(error))
+        flash("Unexpected error, please check data and try again."
+              "  If the error persists, please contact Noisebridge support")
+        return redirect('/index#form')
         # TODO log request data, make sure charge failed
 
     if params['recurring']:

--- a/donate/routes.py
+++ b/donate/routes.py
@@ -55,6 +55,10 @@ def get_donation_params(form):
     charges = [charge for charge
                in form.getlist('charge[amount]')
                if charge not in ["", "other", ' ']]
+
+    if form['donor[email]'] == '':
+        raise KeyError('email')
+
     ret = {
         'charge': charges[0],
         'email': form['donor[email]'],

--- a/donate/vendor/stripe.py
+++ b/donate/vendor/stripe.py
@@ -110,13 +110,13 @@ def charge_monthly(cc_token, email, amount_in_cents, description):
 
 def charge_once(cc_token, email, amount_in_cents, description):
     """ Returns the id of a one-off charge"""
-    customer_id = get_customer(email, cc_token)['customer_id']
+    customer = get_customer(cc_token=cc_token, email=email)
     with stripe_api() as api:
         charge = api.Charge.create(
             amount=amount_in_cents,
             currency='usd',
             description=description,
-            customer=customer_id)
+            customer=customer['customer_id'])
 
     return {'charge_id': charge.id, 'customer_id': charge.customer}
 

--- a/donate/vendor/stripe.py
+++ b/donate/vendor/stripe.py
@@ -40,13 +40,14 @@ def create_charge(recurring, cc_token, amount_in_cents,
     if recurring:
         charge = charge_monthly(
             cc_token,
-            amount_in_cents,
             email,
+            amount_in_cents,
             description)
 
     else:
         charge = charge_once(
             cc_token,
+            email,
             amount_in_cents,
             description)
 
@@ -92,7 +93,7 @@ def create_plan(amount, currency, interval):
     return {'plan_id': plan}
 
 
-def charge_monthly(cc_token, amount_in_cents, email, description):
+def charge_monthly(cc_token, email, amount_in_cents, description):
     """creates a recurring charge, in this case hard coded to the defaults
     in 'get_plan' which is USD and monthly.
     """
@@ -100,29 +101,38 @@ def charge_monthly(cc_token, amount_in_cents, email, description):
     plan = get_plan(amount_in_cents)
 
     with stripe_api() as api:
-        subscription = stripe.Subscription.create(
+        subscription = api.Subscription.create(
             customer=customer['customer_id'],
             items=[{'plan': plan['plan_id']}])
 
     return {**customer, **plan, 'subscription_id': subscription.id}
 
 
-def charge_once(cc_token, amount_in_cents, description):
+def charge_once(cc_token, email, amount_in_cents, description):
     """ Returns the id of a one-off charge"""
+    customer_id = get_customer(email, cc_token)['customer_id']
     with stripe_api() as api:
         charge = api.Charge.create(
             amount=amount_in_cents,
             currency='usd',
             description=description,
-            source=cc_token)
+            customer=customer_id)
 
     return {'charge_id': charge.id, 'customer_id': charge.customer}
 
 
 def get_customer(cc_token, email):
     with stripe_api() as api:
-        customer = api.Customer.create(
-            source=cc_token,
-            email=email)
+        customer_list = api.Customer.list(email=email)
+
+    if len(customer_list) == 0:
+        with stripe_api() as api:
+            customer = api.Customer.create(
+                source=cc_token,
+                email=email)
+    elif len(customer_list) == 1:
+        customer = customer_list.data[0]
+    elif len(customer_list) > 1:
+        raise ValueError("More than one customer for: {}".format(email))
 
     return {'customer_id': customer.id}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -160,6 +160,14 @@ def test_get_donation_params(testapp, test_form):
     assert result['project_select'] == form.vals['project_select']
 
 
+def test_get_donation_params_error(testapp, test_form):
+    app = testapp
+    form = test_form
+    form.vals["donor[email]"] = ''
+    with pytest.raises(KeyError):
+        get_donation_params(form)
+
+
 @pytest.mark.usefixtures('test_db_project')
 def test_model_stripe_data(testapp, test_form, db):
     app = testapp

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -238,3 +238,8 @@ def test_donation_post(flash, create_charge, get_params, testapp,
 
     create_charge.return_value = {'charge_id': 0, 'customer_id': 1}
     response = app.post("/donation", data=test_form, follow_redirects=True)
+
+    create_charge.side_effect = ValueError("bob@email.tld")
+    response = app.post("/donation", data=test_form)
+    assert response.status_code == 302
+


### PR DESCRIPTION
Retrieves stripe customer by email.  If exists, uses the existing customer as the charge source.  If not, creates the customer, then charges the customer.  No charging tokens directly.  This is how old_donate did it, and maintains the existing reporting model in Stripe without interruption.

I found that it is possible to pass a null email where-as it was not possible in the ruby deployment.  A guard has been placed in get_donation_params against it.

