### PR TITLE
nonces everywhere

### DIFF
--- a/donate/app.py
+++ b/donate/app.py
@@ -1,4 +1,3 @@
-import os
 from flask import Flask, Response
 import prometheus_client
 from donate.extensions import db, migrate
@@ -7,8 +6,6 @@ from donate.models import (
     Account,
     Currency,
     Project,
-    StripeDonation,
-    StripePlan,
     Transaction,
     User,
 )
@@ -33,7 +30,8 @@ def create_app(config_object=ProdConfig):
     # Handle metrics requests.
     @app.route("/metrics")
     def metrics():
-        return Response(prometheus_client.generate_latest(), mimetype=prometheus_client.CONTENT_TYPE_LATEST)
+        return Response(prometheus_client.generate_latest(),
+                        mimetype=prometheus_client.CONTENT_TYPE_LATEST)
 
     return(app)
 
@@ -51,6 +49,7 @@ def register_blueprints(app):
     app.register_blueprint(routes.new_project_page)
     app.register_blueprint(routes.thanks_page)
     app.register_blueprint(routes.donation_charges)
+    app.register_blueprint(routes.nonce_page)
 
 
 def register_shellcontext(app):

--- a/donate/models.py
+++ b/donate/models.py
@@ -290,6 +290,6 @@ class DonateConfiguration(db.Model, TimestampMixin):
     __tablename__ = 'donate_configuration'
 
     id = db.Column(db.Integer, primary_key=True)
-    key = db.Column(db.String(32), nullable=False, unique=True)
+    key = db.Column(db.String(64), nullable=False, unique=True)
     type = db.Column(db.String(10), nullable=False)
     value = db.Column(db.String(32), nullable=False)

--- a/donate/static/js/helper.js
+++ b/donate/static/js/helper.js
@@ -1,0 +1,19 @@
+
+
+function donateHttpGetAsync(value, cback)
+{
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            cback(this);
+        }
+    }
+    xhttp.open("GET", "nonce/"+value, true);
+    xhttp.send();
+}
+
+function initStripe(xhttp) {
+    // var data = document.getElementById('special-thing');
+    var data = JSON.parse(xhttp.responseText);
+    stripe = Stripe.setPublishableKey(data);
+}

--- a/donate/templates/base.html
+++ b/donate/templates/base.html
@@ -27,6 +27,7 @@
       {% block head_css_page %}{% endblock head_css_page %}
     {% endblock head_css %}
     {% block head_script_section %}
+      <script src="{{ url_for('static', filename='js/helper.js') }}"></script>
       <script src="https://js.stripe.com/v2/"></script>
       <!-- script>
         var stripe = Stripe.setPublishableKey({# {{ data.stripe_pk }}) #}
@@ -59,7 +60,6 @@
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 
     <!-- Internal scripts -->
-    <!-- script>Stripe.setPublishableKey("{{ data.stripe_pk }}");</script -->
     <script src="{{ url_for('static', filename='js/donate.js') }}"></script>
 
   </body>

--- a/donate/templates/main.html
+++ b/donate/templates/main.html
@@ -2,7 +2,8 @@
 {% block head_script_section %}
   {{ super() }}
   <script>
-    var stripe = Stripe.setPublishableKey("{{ data.stripe_pk }}")
+    var stripe = "asdf";
+    donateHttpGetAsync("{{ data.nonce }}", initStripe, stripe)
   </script>
 {% endblock %}
 {% block content %}

--- a/donate/templates/nonce.html
+++ b/donate/templates/nonce.html
@@ -1,0 +1,3 @@
+{% block content %}
+{{ data.value | tojson }}
+{% endblock %}


### PR DESCRIPTION
added the following:
1) creating of a 32character nonce
2) store to database object (WARNING: this needs a db migrate.  I'll do it, just pointing it out)
3) in the main page view, a nonce is created and stored in the database
4) The page is then served
5) in the served page, there is now javascript (from static/js/helper.js) which makes an async request
at a new "/nonce/<nonce value>" reout
6) If there is a nonce with value <nonce_value> in the database AND it's  less than 60s old, then the stripe public key is served and subsequenctly set by a call back.

So the key is only available in a 60s window from request initiation to the client.

I suspect this will form only one part of  a larger solution, but it is one part, and it is working.

further efforts to obfuscate the key will occur after implementing this, then rolling the key. 