### PR TITLE
Marcidy/nonce refactor

### DIFF
--- a/donate/app.py
+++ b/donate/app.py
@@ -13,7 +13,10 @@ from donate.models import (
     User,
 )
 from donate.vendor.stripe import _get_stripe_key as get_stripe_key
-from donate import routes
+from donate import (
+    routes,
+    nonce
+)
 
 
 def create_app(config_object=ProdConfig):
@@ -51,6 +54,7 @@ def register_blueprints(app):
     app.register_blueprint(routes.new_project_page)
     app.register_blueprint(routes.thanks_page)
     app.register_blueprint(routes.donation_charges)
+    app.register_blueprint(nonce.nonce_page)
 
 
 def register_shellcontext(app):

--- a/donate/models.py
+++ b/donate/models.py
@@ -290,6 +290,6 @@ class DonateConfiguration(db.Model, TimestampMixin):
     __tablename__ = 'donate_configuration'
 
     id = db.Column(db.Integer, primary_key=True)
-    key = db.Column(db.String(32), nullable=False, unique=True)
+    key = db.Column(db.String(64), nullable=False, unique=True)
     type = db.Column(db.String(10), nullable=False)
     value = db.Column(db.String(32), nullable=False)

--- a/donate/nonce.py
+++ b/donate/nonce.py
@@ -1,0 +1,56 @@
+import random
+import string
+from datetime import datetime
+
+from donate.models import DonateConfiguration
+from donate.extensions import db
+from flask import (
+    current_app as app,
+    make_response,
+    render_template,
+    Blueprint,
+)
+
+
+nonce_page = Blueprint('nonce', __name__, template_folder="templates")
+
+
+@nonce_page.route('/nonce/<nonce>', methods=['GET'])
+def denonce(nonce):
+    data = {'value': consume_nonce(nonce)}
+    resp = make_response(render_template('nonce.html', data=data))
+    resp.headers['Content-type'] = 'application/json'
+    return resp
+
+
+def create_nonce():
+    nonce = ''.join(random.choice(string.ascii_letters + string.digits)
+                    for n in range(256))
+    db.session.add(DonateConfiguration(key=nonce, type="nonce", value="true"))
+    db.session.commit()
+    return nonce
+
+
+def consume_nonce(nonce):
+    nonces = db.session.query(DonateConfiguration).filter_by(
+        key=nonce,
+        type="nonce",
+        value="true").all()
+
+    if len(nonces) == 0:
+        return None
+
+    if len(nonces) == 1:
+        nonce = nonces[0]
+        if (datetime.now() - nonce.created_at).total_seconds() <= 60:
+            key = app.get_stripe_key('PUBLIC')
+        for nonce in nonces:
+            db.session.delete(nonce)
+        db.session.commit()
+        return key
+
+    if len(nonces) > 1:
+        for nonce in nonces:
+            db.session.delete(nonce)
+        db.session.commit()
+        return None

--- a/donate/routes.py
+++ b/donate/routes.py
@@ -30,7 +30,7 @@ from donate.vendor.stripe import (
     create_charge,
     get_customer
 )
-
+from donate.nonce import create_nonce
 import stripe
 from stripe import error as se
 
@@ -250,7 +250,7 @@ def index():
 
     # donations = db.session.query(Donation).limit(10)
     donations = []
-    STRIPE_KEY = app.get_stripe_key('PUBLIC')
+    nonce = create_nonce()
 
     return render_template('main.html',
                            data={
@@ -258,7 +258,7 @@ def index():
                                'repo_path': repo_path,
                                'recent_donations': donations,
                                'projects': sorted_projects,
-                               'stripe_pk': STRIPE_KEY
+                               'nonce': nonce
                            })
 
 

--- a/donate/static/js/helper.js
+++ b/donate/static/js/helper.js
@@ -1,0 +1,19 @@
+
+
+function donateHttpGetAsync(value, cback)
+{
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            cback(this);
+        }
+    }
+    xhttp.open("GET", "nonce/"+value, true);
+    xhttp.send();
+}
+
+function initStripe(xhttp) {
+    // var data = document.getElementById('special-thing');
+    var data = JSON.parse(xhttp.responseText);
+    stripe = Stripe.setPublishableKey(data);
+}

--- a/donate/templates/base.html
+++ b/donate/templates/base.html
@@ -27,6 +27,7 @@
       {% block head_css_page %}{% endblock head_css_page %}
     {% endblock head_css %}
     {% block head_script_section %}
+      <script src="{{ url_for('static', filename='js/helper.js') }}"></script>
       <script src="https://js.stripe.com/v2/"></script>
       <!-- script>
         var stripe = Stripe.setPublishableKey({# {{ data.stripe_pk }}) #}
@@ -59,7 +60,6 @@
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 
     <!-- Internal scripts -->
-    <!-- script>Stripe.setPublishableKey("{{ data.stripe_pk }}");</script -->
     <script src="{{ url_for('static', filename='js/donate.js') }}"></script>
 
   </body>

--- a/donate/templates/main.html
+++ b/donate/templates/main.html
@@ -2,7 +2,8 @@
 {% block head_script_section %}
   {{ super() }}
   <script>
-    var stripe = Stripe.setPublishableKey("{{ data.stripe_pk }}")
+    var stripe = "asdf";
+    donateHttpGetAsync("{{ data.nonce }}", initStripe, stripe)
   </script>
 {% endblock %}
 {% block content %}

--- a/donate/templates/nonce.html
+++ b/donate/templates/nonce.html
@@ -1,0 +1,3 @@
+{% block content %}
+{{ data.value | tojson }}
+{% endblock %}


### PR DESCRIPTION
refactored the nonce stuff so it's smaller impact on routes.py.

added the following:

creating of a 32character nonce
store to database object (WARNING: this needs a db migrate. I'll do it, just pointing it out)
in the main page view, a nonce is created and stored in the database
The page is then served
in the served page, there is now javascript (from static/js/helper.js) which makes an async request
at a new "/nonce/" reout
If there is a nonce with value <nonce_value> in the database AND it's less than 60s old, then the stripe public key is served and subsequenctly set by a call back.
So the key is only available in a 60s window from request initiation to the client.

I suspect this will form only one part of a larger solution, but it is one part, and it is working.

further efforts to obfuscate the key will occur after implementing this, then rolling the key.

This PR replaces #34 