### PR TITLE
Simplify landing text

### DIFF
--- a/donate/templates/main.html
+++ b/donate/templates/main.html
@@ -24,23 +24,8 @@
         <div class="row donation-copy">
           <div class="col-md-8 col-md-offset-3">
             <p>
-              Our lease, at 2169 Mission Street, is up in August and the landlord has told us that it won't be renewed. 
-              That throws us into a crunch to find and fund a new space, and move all of our blinky stuff and well-loved 
-              tools before August. We're raising money to fill a war-chest to allow us to afford our new space and cover expenses.
-            </p>
-            <p>
-              Since we last moved, rents for our type of space have almost tripled.  We're looking at several options 
-              for an accessible, industrial space close to public transit, but it's clear that whichever we choose, 
-              we're going to have to deal with a significant rent increase.
-            </p>
-            <p>
               Any donations to Noisebridge are tax deductible as we are a 501(c)(3). Please consider signing up for a 
               monthly donation, as recurring revenue is the best way to keep us afloat.
-            </p>
-            <p>
-              PS. If you have a lead on a cheap industrial space near transit, please let us know ( secretary@noisebridge.net ).
-              Also, if you, or an organization you are a part of would like to discuss a larger donation or loan that could help 
-              us buy a building and ensure a permanent home for Noisebridge, please get in contact!
             </p>
           </div>
         </div>

--- a/donate/templates/main.html
+++ b/donate/templates/main.html
@@ -35,7 +35,7 @@
             </p>
             <p>
               Any donations to Noisebridge are tax deductible as we are a 501(c)(3). Please consider signing up for a 
-              monthly donation, reoccuring revenue is the best way to keep us afloat.
+              monthly donation, as recurring revenue is the best way to keep us afloat.
             </p>
             <p>
               PS. If you have a lead on a cheap industrial space near transit, please let us know ( secretary@noisebridge.net ).


### PR DESCRIPTION
This gets rid of last year's text about the search for a new space and the then-imminent August (2019) deadline. I left the 501(c)(3) text.