### PR TITLE
re-enable recent donations query (untested)

### DIFF
--- a/donate/routes.py
+++ b/donate/routes.py
@@ -248,8 +248,7 @@ def index():
                              .filter(Project.name != "General Fund").all(),
                              key=lambda proj: proj.name)
 
-    # donations = db.session.query(Donation).limit(10)
-    donations = []
+    donations = db.session.query(Donation).limit(10)
     STRIPE_KEY = app.get_stripe_key('PUBLIC')
 
     return render_template('main.html',


### PR DESCRIPTION
Please test! I'm not sure if there's a good reason for commenting out the recent donations, but it seems like a good idea to check if we can re-enable it.