### PR TITLE
Travis badge now reads from .com and links to the build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 Donate
 ======
-.. image:: https://travis-ci.org/noisebridge/python-nb-donate.svg?branch=master
-   :target: https://travis-ci.com/noisebridge/python-nb-donate.svg?branch=master
+.. image:: https://travis-ci.com/noisebridge/python-nb-donate.svg?branch=master
+   :target: https://travis-ci.com/noisebridge/python-nb-donate
+
 A rewrite of Noisebridge's donation site in python using Flask.
 
 


### PR DESCRIPTION
Currently the build is on https://travis-ci.com but the badge was for https://travis-ci.org. Also the target for the link was the badge, not the build, so I've fixed that as well.