### PR TITLE
Update main.html

### DIFF
--- a/donate/templates/main.html
+++ b/donate/templates/main.html
@@ -109,7 +109,7 @@
                     <!-- Credit card details -->
                     <div class="form-group cc-details">
                       <input type="text" class="form-control cc-number" data-stripe="number" inputmode="numeric" placeholder="Card number" required />
-                      <input type="text" class="form-control cc-exp" data-stripe="exp" inputmode="numeric" placeholder="MM/YYYY" required />
+                      <input type="text" class="form-control cc-exp" data-stripe="exp" placeholder="MM/YYYY" required />
                       <input type="text" class="form-control cc-cvc" data-stripe="cvc" inputmode="numeric" placeholder="CVC" />
                     </div>
                     


### PR DESCRIPTION
numeric inputmode doesn't work in this case for iphones.  The iphone numeric keyboard doesn't include the required '/' so the form always fails validation.

I tested this change by making it on the developer console in Safari and validating that I could enter an expiration date on my iphone.